### PR TITLE
add pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /releases
 /test-bin
 /bin/
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.willuhn.jameica</groupId>
+  <artifactId>jameica-datasource</artifactId>
+  <version>2.6.7-SNAPSHOT</version>
+  <name>Jameica Datasource ORM Mapper</name>
+
+  <properties>
+    <encoding>ISO-8859-1</encoding>
+    <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <project.build.sourceDirectory>src/</project.build.sourceDirectory>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>de.willuhn.jameica</groupId>
+      <artifactId>jameica-util</artifactId>
+      <version>2.6.7-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.mckoi</groupId>
+      <artifactId>mckoisqldb</artifactId>
+      <version>1.0.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- weicht von der Konvention ab -->
+    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+    <testSourceDirectory>${basedir}/test</testSourceDirectory>
+
+    <plugins>
+      <!-- reconfigure for source, target, encoding -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.source}</target>
+        </configuration>
+      </plugin>
+
+      <!-- attach sources during package phase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- attach javadoc during package phase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <!-- disable doclint in jdk8 -->
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
Das gleiche nochmal für datasource.

Damit das Projekt kompiliert, zieht es sich immer die Sourcen aktuell aus mvn central -- siehe den "dependencies"-Abschnitt in der pom.xml.

Die jameica-util-Library muss man vorher installieren. Dazu das jameica-util-repository als erstes klonen, dann ein "mvn install" ausführen. Dann kann auch diese Library in das lokale Repository mittels "mvn install" installiert werden.
