### PR TITLE
Javadoc: Fixes und Überarbeitungen

### DIFF
--- a/src/de/willuhn/datasource/BeanUtil.java
+++ b/src/de/willuhn/datasource/BeanUtil.java
@@ -24,7 +24,8 @@ import de.willuhn.logging.Logger;
 
 
 /**
- * Hilfsklasse, um auf gemeinsame Weise sowhl GenericObjects als auch regulaere Beans generisch nutzen zu koennen.
+ * Hilfsklasse, um auf gemeinsame Weise sowohl {@link GenericObject}
+ * als auch regulaere Beans generisch nutzen zu koennen.
  */
 public class BeanUtil
 {
@@ -164,7 +165,9 @@ public class BeanUtil
 
   /**
    * Liefert eine toString-Repraesentation des Objektes.
-   * Handelt es sich um ein GenericObject, wird der Wert des Primaer-Attributes zurueckgeliefert.
+   *
+   * <p>Handelt es sich um ein {@link GenericObject}, wird der Wert des Primaer-Attributes zurueckgeliefert.
+   *
    * @param bean die Bean.
    * @return die String-Repraesentation.
    * @throws RemoteException
@@ -185,10 +188,12 @@ public class BeanUtil
   
   /**
    * Vergleicht zwei Objekte.
-   * Handelt es sich um Objekte des Typs GenericObject, werden deren equals-Methoden verwendet.
+   *
+   * <p>Handelt es sich um Objekte des Typs {@link GenericObject}, werden deren equals-Methoden verwendet.
+   *
    * @param a Objekt a.
    * @param b Objekt b.
-   * @return True, wenn beide Objekte gleich sind.
+   * @return {@code true}, wenn beide Objekte gleich sind.
    * @throws RemoteException
    */
   public static boolean equals(Object a, Object b) throws RemoteException

--- a/src/de/willuhn/datasource/GenericIterator.java
+++ b/src/de/willuhn/datasource/GenericIterator.java
@@ -22,8 +22,8 @@ public interface GenericIterator<T extends GenericObject> extends Remote
 {
 
 	/**
-	 * Liefert true, wenn weitere Elemente in diesem Iterator existieren.
-	 * @return true, wenn weitere Elemente vorhanden sind.
+	 * Prueft, ob weitere Elemente in diesem Iterator existieren.
+	 * @return {@code true}, wenn weitere Elemente vorhanden sind.
 	 * @throws RemoteException
 	 */
 	public boolean hasNext() throws RemoteException;
@@ -59,7 +59,7 @@ public interface GenericIterator<T extends GenericObject> extends Remote
   /**
    * Prueft, ob das uebergebene Objekt in der aktuellen Liste vorhanden ist.
    * @param o das zu pruefende Objekt.
-   * @return null wenn kein Objekt uebereinstimmt, andernfalls das ueberinstimmende Objekt aus dieser Liste.
+   * @return {@code null} wenn kein Objekt uebereinstimmt, andernfalls das ueberinstimmende Objekt aus dieser Liste.
    * @throws RemoteException
    */
   public T contains(T o) throws RemoteException;

--- a/src/de/willuhn/datasource/GenericObject.java
+++ b/src/de/willuhn/datasource/GenericObject.java
@@ -15,9 +15,10 @@ import java.rmi.RemoteException;
 
 /**
  * Generisches RMI-faehiges Objekt, welches Attribute besitzt.
- * Das kann also so ziemlich alles sein, vom Kalendereintrag bis
+ *
+ * <p>Das kann also so ziemlich alles sein, vom Kalendereintrag bis
  * zum Datensatz in einer Datenbank. Entscheidendes Merkmal ist,
- * dass es eine Funktion getAttribute(AliasName) besitzt,
+ * dass es eine Funktion {@link #getAttribute(String)} besitzt,
  * mit der die Werte der Attribute ueber Aliasnamen abgefragt
  * werden koennen. 
  */
@@ -49,9 +50,12 @@ public interface GenericObject extends Remote {
 
 	/**
 	 * Liefert den Namen des Primaer-Attributes dieses Objektes.
-	 * Hintergrund: Wenn man z.Bsp. in einer Select-Box nur einen Wert
+	 *
+	 * <p>Hintergrund: Wenn man z.Bsp. in einer Select-Box nur einen Wert
 	 * anzeigen kann, dann wird dieser genommen.
-	 * Achtung: Die Funktion liefert nicht den Wert des Attributes sondern nur dessen Namen.
+	 *
+	 * <p>Achtung: Die Funktion liefert nicht den Wert des Attributes sondern nur dessen Namen.
+	 *
 	 * @return Name des Primaer-Attributes.
 	 * @throws RemoteException im Fehlerfall.
 	 */
@@ -59,7 +63,8 @@ public interface GenericObject extends Remote {
 
 	/**
 	 * Vergleicht dieses Objekt mit dem uebergebenen.
-	 * Achtung: Wir ueberschreiben hier nicht die equals-Funktion von <code>Object</code>
+	 *
+	 * <p>Achtung: Wir ueberschreiben hier nicht {@link Object#equals(Object)},
 	 * da das via RMI nicht geht.
 	 * @param other das zu vergleichende Objekt.
 	 * @return true, die Objekte gleiche Eigenschaften besitzen.

--- a/src/de/willuhn/datasource/GenericObjectNode.java
+++ b/src/de/willuhn/datasource/GenericObjectNode.java
@@ -13,7 +13,7 @@ package de.willuhn.datasource;
 import java.rmi.RemoteException;
 
 /**
- * Generisches RMI-faehiges Objekt, welches von genericObject
+ * Generisches RMI-faehiges Objekt, welches von {@link GenericObject}
  * abgeleitet ist, jedoch noch Funktionen zur Abbildung einer Baumstruktur mitbringt.
  */ 
 public interface GenericObjectNode extends GenericObject
@@ -39,9 +39,9 @@ public interface GenericObjectNode extends GenericObject
 
 
   /**
-   * Liefert das Eltern-Element des aktuellen oder null, wenn es sich
-   * bereits auf oberster Ebene befindet.
-   * @return das Eltern-Objekt oder null.
+   * Liefert das Eltern-Element des aktuellen Elements
+   *
+   * @return das Eltern-Objekt oder {@code null}, wenn es sich bereits auf oberster Ebene befindet.
    * @throws RemoteException
    */
   public GenericObjectNode getParent() throws RemoteException;

--- a/src/de/willuhn/datasource/Service.java
+++ b/src/de/willuhn/datasource/Service.java
@@ -29,13 +29,13 @@ public interface Service extends Remote
   /**
    * Prueft, ob dieser Service gestartet ist.
    * @throws RemoteException
-   * @return true wenn er gestartet ist, sonst false.
+   * @return {@code true} wenn er gestartet ist, sonst {@code false}.
    */
   public boolean isStarted() throws RemoteException;
 
 	/**
 	 * Prueft, ob der Service gestartet werden darf.
-   * @return true, wenn er gestartet werden darf, sonst false.
+   * @return {@code true}, wenn er gestartet werden darf, sonst {@code false}.
    * @throws RemoteException
    */
   public boolean isStartable() throws RemoteException;

--- a/src/de/willuhn/datasource/db/AbstractDBObject.java
+++ b/src/de/willuhn/datasource/db/AbstractDBObject.java
@@ -134,7 +134,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
     }
     
     if (isInitialized())
-      return; // allready initialized
+      return; // already initialized
     
     // Checken, ob die Datenbank Uppercase ist
     this.upper = Boolean.getBoolean(getService().getClass().getName() + ".uppercase");
@@ -1200,7 +1200,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
 
       if (!this.inTransaction())
       {
-        Logger.debug("[rollback] rollback without begin or transaction allready rolled back");
+        Logger.debug("[rollback] rollback without begin or transaction already rolled back");
         return;
       }
       
@@ -1239,7 +1239,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
     {
       if (!this.inTransaction())
       {
-        Logger.debug("[commit] transaction commit without begin or transaction allready commited, skipping");
+        Logger.debug("[commit] transaction commit without begin or transaction already commited, skipping");
         return;
       }
 

--- a/src/de/willuhn/datasource/db/AbstractDBObject.java
+++ b/src/de/willuhn/datasource/db/AbstractDBObject.java
@@ -785,7 +785,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
    * Liefert das automatisch erzeugte SQL-Statement fuer ein Update.
    * Kann bei Bedarf ueberschrieben um ein vom dynamisch erzeugten
    * abweichendes Statement f�r die Speicherung zu verwenden.
-   * Die Funktion darf <null> zurueckliefern, wenn nichts zu aendern ist.  
+   * Die Funktion darf {@code null} zurueckliefern, wenn nichts zu aendern ist.
    * @return das erzeugte SQL-Statement.
    * @throws RemoteException wenn beim Erzugen des Statements ein Fehler auftrat.
    */

--- a/src/de/willuhn/datasource/db/AbstractDBObject.java
+++ b/src/de/willuhn/datasource/db/AbstractDBObject.java
@@ -563,9 +563,9 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
    * @param fieldName Name des Feldes.
    * @param value neuer Wert des Feldes.
    * Muss vom Typ String, Date, Timestamp, Double, Integer oder DBObject sein.<br>
-   * Ist der Parameter vom Typ <code>dbObject</code> nimmt die Funktion an, dass
+   * Ist der Parameter vom Typ {@link DBObject} nimmt die Funktion an, dass
    * es sich um einen Fremdschluessel handelt und speichert automatisch statt
-   * des Objektes selbst nur dessen ID mittels <code>new Integer(((DBObject)value).getID())</code>.
+   * des Objektes selbst nur dessen ID mittels {@code new Integer(((DBObject)value).getID())}.
    * @return vorheriger Wert des Feldes.
    * @throws RemoteException
    */
@@ -637,7 +637,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
    * durchaus fehlschlagen, wenn ein Objekt mit dieser ID bereits in
    * der Datenbank existiert.
    * @throws RemoteException Wenn beim Speichern Fehler aufgetreten sind.
-   * @throws ApplicationException Durch <code>insertCheck()</code> erzeugte Benutzerfehler.
+   * @throws ApplicationException Durch {@link #insertCheck()} erzeugte Benutzerfehler.
    */
   public void insert() throws RemoteException, ApplicationException
   {
@@ -725,7 +725,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
    * Aktualisiert das Objekt explizit in der Datenbank.
    * Wenn es sich um ein neues Objekt handelt, wird das Update fehlschlagen.
    * @throws RemoteException Wenn beim Update Fehler aufgetreten sind.
-   * @throws ApplicationException durch <code>updateCheck()</code> erzeugte Benutzer-Fehler.
+   * @throws ApplicationException durch {@link #updateCheck()} erzeugte Benutzer-Fehler.
    */
   private void update() throws RemoteException, ApplicationException
   {
@@ -1013,15 +1013,18 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
   }
 
   /**
-   * Liefert das automatisch erzeugte SQL-Statement fuer die Erzeugung einer Liste
-   * dieses Typs.
-   * ACHTUNG: Das Statement muss ein Feld mit der Bezeichnung zurueckgeben,
-   * die <code>getIDField</code> auch liefert, da das von DBIteratorImpl gelesen wird.
-   * Also z.Bsp. "select " + getIDField() + " from " + getTableName().
-   * Kann bei Bedarf �berschrieben um ein abweichendes Statement zu verwenden.
-   * Die Funktion muss das Statement nur dewegen als String zurueckliefern,
-   * weil es typischerweise von DBIterator weiterverwendet wird und dort eventuell
-   * noch weitere Filterkriterien hinzugefuegt werden koennen muessen.  
+   * Liefert das automatisch erzeugte SQL-Statement fuer die Erzeugung einer Liste dieses Typs.
+   *
+   * <p>ACHTUNG: Das Statement muss ein Feld mit der Bezeichnung zurueckgeben, die {@link #getIDField()} auch liefert,
+   * da das von {@link DBIteratorImpl} gelesen wird.
+   * Also z.Bsp. {@code "select " + getIDField() + " from " + getTableName()}.
+   *
+   * <p>Kann bei Bedarf �berschrieben werden, um ein abweichendes Statement zu verwenden.
+   *
+   * <p>Die Funktion muss das Statement nur dewegen als String zurueckliefern, weil es typischerweise von
+   * {@link DBIterator} weiterverwendet wird und dort eventuell noch weitere Filterkriterien hinzugefuegt werden
+   * koennen muessen.
+   *
    * @return das erzeugte SQL-Statement.
    */
   protected String getListQuery()
@@ -1036,11 +1039,15 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
 
 	/**
 	 * Liefert das automatisch erzeugte SQL-Statement zum Laden des Objektes.
-	 * Hierbei werden die Eigenschaften des Objektes geladen, dessen ID aktuell
-	 * von <code>getID()</code> geliefert wird.
-	 * ACHTUNG: Das Statement muss alle Felder selecten (*).
-	 * Also z.Bsp. "select * from " + getTableName() + " where " + getIDField() + " = " + getID();
-	 * Kann bei Bedarf �berschrieben um ein abweichendes Statement zu verwenden.
+	 *
+	 * <p>Hierbei werden die Eigenschaften des Objektes geladen, dessen ID aktuell
+	 * von {@link #getID()} geliefert wird.
+	 *
+	 * <p>ACHTUNG: Das Statement muss alle Felder selecten (*).
+	 * Also z.Bsp. {@code "select * from " + getTableName() + " where " + getIDField() + " = " + getID();}
+	 *
+	 * <p>Kann bei Bedarf �berschrieben werden, um ein abweichendes Statement zu verwenden.
+	 *
 	 * @return das erzeugte SQL-Statement.
 	 * @throws RemoteException Wenn beim Erzeugen des Statements ein Fehler auftrat.
 	 */
@@ -1065,11 +1072,11 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
 
   /**
    * Macht sozusagen das Typ-Mapping bei Insert und Update.
-   * Hintergrund: Die Funktionen <code>getInsertSQL()</code> und
-   * <code>getUpdateSQL()</code> erzeugen ja die Statements fuer
-   * Insert und Update. Da ein PreparedStatement ja typsichere
-   * Werte haben muss, rufen beide Funktion diese hier auf, um
-   * hier die Werte korrekt setzen zu lassen.
+   *
+   * <p>Hintergrund: Die Funktionen {@link #getInsertSQL()} und {@link #getUpdateSQL()} erzeugen die Statements fuer
+   * Insert und Update. Da ein {@link PreparedStatement} typsichere Werte haben muss, rufen beide Funktion diese hier
+   * auf, um hier die Werte korrekt setzen zu lassen.
+   *
    * @param stmt das PreparedStatement.
    * @param index der Index im Statement.
    * @param type Bezeichnung des Feld-Typs entspechend der types-Mappingtabelle.
@@ -1114,7 +1121,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
   public abstract String getPrimaryAttribute() throws RemoteException;
 
   /**
-   * Diese Methode wird intern vor der Ausfuehrung von delete()
+   * Diese Methode wird intern vor der Ausfuehrung von {@link #delete()}
    * aufgerufen. Sie muss �berschrieben werden, damit das Fachobjekt
    * vor dem Durchf�hren der L�schaktion Pr�fungen vornehmen kann.
    * Z.Bsp. ob eventuell noch Abhaengigkeiten existieren und
@@ -1126,7 +1133,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
   }
 
   /**
-   * Diese Methode wird intern vor der Ausfuehrung von insert()
+   * Diese Methode wird intern vor der Ausfuehrung von {@link #insert()}
    * aufgerufen. Sie muss �berschrieben werden, damit das Fachobjekt
    * vor dem Durchf�hren der Speicherung Pr�fungen vornehmen kann.
    * Z.Bsp. ob alle Pflichtfelder ausgef�llt sind und korrekte Werte enthalten.
@@ -1137,7 +1144,7 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
   }
 
   /**
-   * Diese Methode wird intern vor der Ausfuehrung von update()
+   * Diese Methode wird intern vor der Ausfuehrung von {@link #update()}
    * aufgerufen. Sie muss �berschrieben werden, damit das Fachobjekt
    * vor dem Durchf�hren der Speicherung Pr�fungen vornehmen kann.
    * Z.Bsp. ob alle Pflichtfelder ausgef�llt sind und korrekte Werte enthalten.
@@ -1150,9 +1157,9 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
   /**
    * Prueft, ob das angegebene Feld ein Fremschluessel zu einer
    * anderen Tabelle ist. Wenn das der Fall ist, liefert es die
-   * Klasse, die die Fremd-Tabelle abbildet. Andernfalls null.
+   * Klasse, die die Fremd-Tabelle abbildet.
    * @param field das zu pruefende Feld.
-   * @return Klasse (abgeleitet von DBObject) welche den Fremdschluessel abbildet oder null. 
+   * @return Klasse (abgeleitet von DBObject) welche den Fremdschluessel abbildet oder {@code null}.
    * @throws RemoteException im Fehlerfall.
    */
   protected Class getForeignObject(String field) throws RemoteException

--- a/src/de/willuhn/datasource/db/DBIteratorImpl.java
+++ b/src/de/willuhn/datasource/db/DBIteratorImpl.java
@@ -97,7 +97,7 @@ public class DBIteratorImpl<T extends AbstractDBObject> extends UnicastRemoteObj
    */
   public void setOrder(String order) throws RemoteException {
     if (this.initialized)
-      return; // allready initialized
+      return; // already initialized
 
     this.order = " " + order;
   }
@@ -124,7 +124,7 @@ public class DBIteratorImpl<T extends AbstractDBObject> extends UnicastRemoteObj
   public void addFilter(String filter, Object... p) throws RemoteException
   {
     if (this.initialized)
-      return; // allready initialized
+      return; // already initialized
 
     if (filter == null)
       return; // no filter given
@@ -152,7 +152,7 @@ public class DBIteratorImpl<T extends AbstractDBObject> extends UnicastRemoteObj
   public void join(String table) throws RemoteException
   {
     if (this.initialized)
-      return; // allready initialized
+      return; // already initialized
     
     if (table == null)
       return;
@@ -197,7 +197,7 @@ public class DBIteratorImpl<T extends AbstractDBObject> extends UnicastRemoteObj
    */
   private void init() throws RemoteException {
     if (this.initialized)
-      return; // allready initialzed
+      return; // already initialzed
 
 		PreparedStatement stmt = null;
     String sql             = null;

--- a/src/de/willuhn/datasource/db/DBServiceImpl.java
+++ b/src/de/willuhn/datasource/db/DBServiceImpl.java
@@ -144,7 +144,7 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
 	}
   
   /**
-   * Liefert den Client-Host oder <code>null</code>.
+   * Liefert den Client-Host oder {@code null}.
    * @return ein Client-Identifier.
    */
   private String getClientIdentifier()
@@ -214,7 +214,7 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
   /**
    * Kann von abgeleiteten Klassen ueberschrieben werden, um die Connection
    * zu testen.
-   * @param conn die zu testende Connection. Ist nie <code>null</code>.
+   * @param conn die zu testende Connection. Ist nie {@code null}.
    * @throws SQLException
    */
   protected void checkConnection(Connection conn) throws SQLException
@@ -224,13 +224,16 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
   /**
    * Definiert einen optionalen Classfinder, der von dem Service
    * zum Laden von Objekten genommen werden soll.
-   * Konkret wird er in <code>creatObject</code> und  <code>createList</code>
+   *
+   * <p>Konkret wird er in {@link #createObject(Class, String)} und {@link #createList(Class)}
    * verwendet, um zum uebergebenen Interface eine passende Implementierung
-   * zu finden. Dabei wird die Funktion <code>findImplementor()</code> im
-   * ClassFinder befragt.<br>
-   * Wurde kein ClassFinder angegeben, versucht der Service direkt die
+   * zu finden. Dabei wird die Funktion {@link ClassFinder#findImplementors(Class)}
+   * befragt.
+   *
+   * <p>Wurde kein ClassFinder angegeben, versucht der Service direkt die
    * uebergebene Klasse zu instanziieren. Ist dies der Fall, koennen den
    * beiden create-Methoden natuerliche keine Interfaces-Klassen uebergeben werden.
+   *
    * @param finder zu verwendender ClassFinder.
    */
   protected void setClassFinder(ClassFinder finder)
@@ -240,7 +243,7 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
 
 	/**
 	 * Definiert einen optionalen benutzerdefinierten Classloader.
-	 * Wird er nicht gesetzt, wird <code>Class.forName()</code> benutzt.
+	 * Wird er nicht gesetzt, wird {@link Class#forName(String)} benutzt.
    * @param loader Benutzerdefinierter Classloader.
    */
   protected void setClassloader(ClassLoader loader)
@@ -559,7 +562,7 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
 
   /**
    * Liefert den Transaction-Isolation-Level.
-   * @return transactionIsolationLevel Transaction-Isolation-Level (Default:-1). 
+   * @return Transaction-Isolation-Level (Default:-1).
    * @see Connection#TRANSACTION_NONE
    * @see Connection#TRANSACTION_READ_COMMITTED
    * @see Connection#TRANSACTION_READ_UNCOMMITTED
@@ -573,9 +576,10 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
   }
   
   /**
-   * Liefert true, wenn autocommit aktiv sein soll.
-   * Default: false.
-   * @return Autocommit.
+   * Status von Auto-Commit.
+   *
+   * <p>Default: false.
+   * @return {@code true}, wenn Auto-Commit aktiv ist.
    * @throws RemoteException
    */
   protected boolean getAutoCommit() throws RemoteException
@@ -584,13 +588,16 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
   }
   
   /**
-   * Liefert true, wenn der DB-Service bei INSERT-Queries <b>vorher</b> die zu verwendende ID ermitteln soll.
-   * MySQL zum besitzt eine auto_increment-Funktion, mit der es nicht notwendig ist, die ID beim
+   * Muss der DB-Service bei INSERT-Queries <b>vorher</b> die zu verwendende ID ermitteln?
+   *
+   * <p>MySQL zum besitzt eine {@code auto_increment}-Funktion, mit der es nicht notwendig ist, die ID beim
    * Insert mit anzugeben. Falls die Datenbank das jedoch nicht korrekt kann (z.Bsp. McKoi), dann
-   * kann die Funktion true liefern. In dem Fall wird vor dem Insert ein "select max(id)+1 from table"
+   * kann die Funktion {@code true} liefern. In dem Fall wird vor dem Insert ein "{@code select max(id)+1 from table}"
    * ausgefuehrt und diese ID fuer das Insert verwendet.
-   * <b>Standard-Wert: TRUE</b>
-   * @return true, wenn bei Inserts vorher die ID ermittelt werden soll.
+   *
+   * <p>Standard-Wert: {@code true}
+   *
+   * @return {@code true}, wenn bei Inserts vorher die ID ermittelt werden soll.
    * @throws RemoteException
    */
   protected boolean getInsertWithID() throws RemoteException

--- a/src/de/willuhn/datasource/db/DBServiceImpl.java
+++ b/src/de/willuhn/datasource/db/DBServiceImpl.java
@@ -307,7 +307,7 @@ public class DBServiceImpl extends UnicastRemoteObject implements DBService
   {
     if (!started)
     {
-    	Logger.info("service allready stopped");
+      Logger.info("service already stopped");
 			return;
     }
 

--- a/src/de/willuhn/datasource/db/EmbeddedDatabase.java
+++ b/src/de/willuhn/datasource/db/EmbeddedDatabase.java
@@ -174,7 +174,7 @@ public class EmbeddedDatabase
 
 	/**
 	 * Fuehrt das uebergebene File mit SQL-Kommandos auf der Datenbank aus.
-	 * Die Funktion liefert kein DBIteratorImpl zurueck, weil sie typischerweise
+	 * Die Funktion liefert kein {@link DBIteratorImpl} zurueck, weil sie typischerweise
 	 * fuer die Erstellung der Tabellen verwendet werden sollte. Wenn das
 	 * Plugin also bei der Installation seine SQL-Tabellen erstellen will,
 	 * kann es das am besten hier machen.
@@ -302,7 +302,7 @@ public class EmbeddedDatabase
   /**
    * Repariert die Datenbank.
    * @param terminal Terminal, welches zur Ausgabe und Interaktion verwendet werden soll.
-   * <code>UserTerminal</code> ist ein Interface und muss vom Benutzer implementiert werden.
+   * {@link UserTerminal} ist ein Interface und muss vom Benutzer implementiert werden.
    */
   public void repair(UserTerminal terminal)
 	{

--- a/src/de/willuhn/datasource/db/MyDriver.java
+++ b/src/de/willuhn/datasource/db/MyDriver.java
@@ -19,15 +19,17 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 /**
- * Hilfsklasse da java.sql.DriverManager nur Driver akzeptiert,
- * die vom Systemclassloader geladen worden.
- * Siehe: http://www.kfu.com/~nsayer/Java/dyn-jdbc.html
+ * Hilfsklasse da {@link java.sql.DriverManager} nur Driver akzeptiert,
+ * die vom System-Classloader geladen worden.
+ *
  * Sprich: Bringt zum Beispiel ein Jameica-Plugin eigene JDBC-Treiber
- * mit, wuerde java.sql.DriverManager die nicht haben wollen, weil
+ * mit, wuerde {@link java.sql.DriverManager} die nicht haben wollen, weil
  * sie nicht vom System-Classloader kommen. Daher zimmern wir
  * uns einen Wrapper um den eigentlichen Driver. Hauptsache MyDriver
  * ist vom SystemClassloader geladen. Wo der tatsaechliche Treiber
  * herkommt, interessiert den DriverManager nicht ;).
+ *
+ * @see <a href="http://www.kfu.com/~nsayer/Java/dyn-jdbc.html" target="_top">http://www.kfu.com/~nsayer/Java/dyn-jdbc.html</a>
  */
 public class MyDriver implements Driver
 {

--- a/src/de/willuhn/datasource/db/ObjectMetaCache.java
+++ b/src/de/willuhn/datasource/db/ObjectMetaCache.java
@@ -18,7 +18,7 @@ import de.willuhn.util.Session;
 /**
  * Diese Klasse ist (wie der Name schon sagt ;) ein Cache.
  * Und zwar fuer die Meta-Daten der Business-Objekte. Und zwar:
- * AbstractDBObject ist ja die Basisklasse aller Business-Objekte.
+ * {@link AbstractDBObject} ist ja die Basisklasse aller Business-Objekte.
  * Und diese ermittelt die Eigenschaften der Objekte "on the fly"
  * aus den Meta-Daten der SQL-Tabelle. Dies ist ein zeitraubender
  * Prozess, der nicht fuer jede Instanziierung eines Objektes neu
@@ -39,7 +39,7 @@ public class ObjectMetaCache
   private static long all = 0;
 
   /**
-   * Liefert die Meta-Daten einer Klasse oder null.
+   * Liefert die Meta-Daten einer Klasse oder {@code null}.
    * @param service Klasse des Service.
    * @param objectType Klasse des Objekt-Typs.
    * @return Die Metadaten.
@@ -60,7 +60,7 @@ public class ObjectMetaCache
   }
 
   /**
-   * Fuegt dem Cache die Meta-Daten einer DBObject-Klasse hinzu.
+   * Fuegt dem Cache die Meta-Daten einer {@link de.willuhn.datasource.rmi.DBObject}-Klasse hinzu.
    * @param service Klasse des Service.
    * @param objectType Klasse des Objekt-Typs.
    * @param fields Hashmap mit den Metadaten (key=Feldnamen,value=Datentyp).

--- a/src/de/willuhn/datasource/db/types/TypeRegistry.java
+++ b/src/de/willuhn/datasource/db/types/TypeRegistry.java
@@ -58,7 +58,7 @@ public class TypeRegistry
    * Die Funktion beruecksichtigt KEINE Gross-Kleinschreibung.
    * @param name Name des Feld-Typs.
    * @return Implementierung des Typs. Die Funktion liefert nie
-   * <code>null</code> sondern hoechstens TYPE_DEFAULT.
+   * {@code null} sondern hoechstens {@link #TYPE_DEFAULT}.
    */
   public static Type getType(String name)
   {

--- a/src/de/willuhn/datasource/rmi/Changeable.java
+++ b/src/de/willuhn/datasource/rmi/Changeable.java
@@ -48,19 +48,23 @@ public interface Changeable
 
 	/**
 	 * Prueft, ob es sich um ein neues Objekt oder ein bereits in der Datenbank existierendes handelt.
-	 * @return true, wenn es neu ist, andernfalls false.
+	 * @return {@code true}, wenn es neu ist, andernfalls {@code false}.
 	 * @throws RemoteException im Fehlerfall.
 	 */
 	public boolean isNewObject() throws RemoteException;
 
   /**
    * Ueberschreibt dieses Objekt mit den Attributen des uebergebenen.
-   * Dabei werden nur die Werte der Attribute ueberschrieben - nichts anderes.
+   *
+   * <p>Dabei werden nur die Werte der Attribute ueberschrieben - nichts anderes.
    * Also auch keine Meta-Daten oder aehnliches.
-   * Handelt es sich bei der Quelle um ein Objekt fremden Typs, wird nichts ueberschrieben.
-   * Hinweis: Es werden nur die Attribute ueberschrieben, es wird jedoch
+   *
+   * <p>Handelt es sich bei der Quelle um ein Objekt fremden Typs, wird nichts ueberschrieben.
+   *
+   * <p>Hinweis: Es werden nur die Attribute ueberschrieben, es wird jedoch
    * noch nicht gespeichert. Sollen die Aenderungen also dauerhaft uebernommen
-   * werden, muss anschliessend noch ein <code>store()</code> aufgerufen werden.
+   * werden, muss anschliessend noch ein {@link #store()} aufgerufen werden.
+   *
    * @param object das Objekt, welches als Quelle verwendet werden soll.
    * @throws RemoteException im Fehlerfall.
    */

--- a/src/de/willuhn/datasource/rmi/DBIterator.java
+++ b/src/de/willuhn/datasource/rmi/DBIterator.java
@@ -24,12 +24,12 @@ public interface DBIterator<T extends DBObject> extends GenericIterator<T>
 
   /**
    * Fuegt dem Iterator einen zusaetzlichen Filter hinzu, der
-   * sich auf die Anzahl der Treffer auswirkt. Bsp:
-   * addFilter("kontonummer='2020'");
-   * Bewirkt, dass eine zusaetzliche Where-Klausel "where kontonummer='2020'"
+   * sich auf die Anzahl der Treffer auswirkt.
+   *
+   * <p>Bsp: {@code addFilter("kontonummer='2020'");} bewirkt, dass
+   * eine zusaetzliche Where-Klausel "where kontonummer='2020'"
    * hinzugefuegt wird.
    * @param filter ein zusaetzlicher SQL-Filter.
-   * Z.Bsp.: "konto_id = 20".
    * @throws RemoteException
    */
   public void addFilter(String filter) throws RemoteException;
@@ -39,15 +39,18 @@ public interface DBIterator<T extends DBObject> extends GenericIterator<T>
    * Unterschied, dass ueber das Objekt-Array zusaetzliche Parameter
    * angegeben werden koennen, mit denen dann ein PreparedStatement
    * gefuellt wird.
-   * Mann kann also entweder schreiben:
-   * <code>addFilter("kontonummer='200'");</code>
+   *
+   * <p>Man kann also entweder schreiben:
+   * {@code addFilter("kontonummer='200'");}
    * oder
-   * <code>addFilter("kontonummer=?","200");</code>
-   * Die Verwendung des PreparedStatements schuetzt vor SQL-Injections.
-   * @see DBIterator#addFilter(String)
+   * {@code addFilter("kontonummer=?","200");}
+   *
+   * <p><b>Die Verwendung des PreparedStatements schuetzt vor SQL-Injections.</b>
+   *
    * @param filter ein zusaetzlicher Filter.
-   * @param params
+   * @param params die Werte für den Filter
    * @throws RemoteException
+   * @see DBIterator#addFilter(String)
    */
   public void addFilter(String filter, Object... params) throws RemoteException;
   
@@ -66,7 +69,7 @@ public interface DBIterator<T extends DBObject> extends GenericIterator<T>
   public void setOrder(String order) throws RemoteException;
   
   /**
-   * Fuegt ein "limit {i}" dem Statement hinzu.
+   * Fuegt ein "{@code limit {i}}" dem Statement hinzu.
    * @param i Hoehe des Limit.
    * @throws RemoteException
    */

--- a/src/de/willuhn/datasource/rmi/DBObject.java
+++ b/src/de/willuhn/datasource/rmi/DBObject.java
@@ -15,7 +15,7 @@ import java.rmi.RemoteException;
 import de.willuhn.datasource.GenericObject;
 
 /**
- * Erweiterung des GenericObjects um Datenbank-Funktionalitaet.
+ * Erweiterung von {@link GenericObject} um Datenbank-Funktionalitaet.
  */
 public interface DBObject extends GenericObject, Transactionable, Changeable
 {
@@ -30,13 +30,14 @@ public interface DBObject extends GenericObject, Transactionable, Changeable
 
   /**
    * Liefert den Wert des angegebenen Attributes.
-   * Aber die Funktion ist richtig schlau ;)
-   * Sie checkt naemlich den Typ des Feldes in der Datenbank und
-   * liefert nicht nur einen String sondern den korrespondierenden
-   * Java-Typ. Insofern die Businessklasse die Funktion
-   * getForeignObject(String field) sinnvoll uberschrieben hat, liefert
-   * die Funktion bei Fremdschluesseln sogar gleich das entsprechende
-   * Objekt aus der Verknuepfungstabelle.
+   *
+   * <p>Aber die Funktion ist richtig schlau ;)
+   * Sie checkt naemlich den Typ des Feldes in der Datenbank und liefert nicht nur einen String sondern den
+   * korrespondierenden Java-Typ.
+   * Insofern die Businessklasse die Funktion {@link de.willuhn.datasource.db.AbstractDBObject#getForeignObject(String)}
+   * sinnvoll uberschrieben hat, liefert die Funktion bei Fremdschluesseln sogar gleich das entsprechende Objekt aus der
+   * Verknuepfungstabelle.
+   *
    * @param name Name des Feldes.
    * @return Wert des Feldes.
    * @throws RemoteException im Fehlerfall.
@@ -46,10 +47,10 @@ public interface DBObject extends GenericObject, Transactionable, Changeable
 
   /**
    * Liefert den Attributtyp des uebergebenen Feldes.
-   * Siehe DBObject.ATTRIBUTETYPE_*.
    * @param attributeName Name des Attributes.
-   * @return Konstante fuer den Attributtyp. Siehe DBObject.ATTRIBUTETYPE_*.
+   * @return Konstante fuer den Attributtyp.
    * @throws RemoteException im Fehlerfall.
+   * @see de.willuhn.datasource.db.AbstractDBObject#setAttribute(String, Object)
    */
   public String getAttributeType(String attributeName) throws RemoteException;
 

--- a/src/de/willuhn/datasource/rmi/DBService.java
+++ b/src/de/willuhn/datasource/rmi/DBService.java
@@ -11,6 +11,7 @@
 package de.willuhn.datasource.rmi;
 
 import java.rmi.RemoteException;
+import java.sql.ResultSet;
 
 import de.willuhn.datasource.Service;
 
@@ -32,7 +33,7 @@ public interface DBService extends Service
 	 * Erzeugt ein neues Objekt des angegebenen Typs.
 	 * @param clazz Name der Klasse des zu erzeugenden Objektes.
 	 * @param identifier der eindeutige Identifier des Objektes.
-	 * Kann null sein, wenn ein neues Objekt erzeugt werden soll.
+	 * Kann {@code null} sein, wenn ein neues Objekt erzeugt werden soll.
 	 * Andernfalls wird das mit dem genannten Identifier geladen.
 	 * @return Das erzeugte Objekt
 	 * @throws RemoteException
@@ -40,7 +41,7 @@ public interface DBService extends Service
 	public <T extends DBObject> T createObject(Class<? extends DBObject> clazz, String identifier) throws RemoteException;
 
   /**
-   * Fuehrt ein SQL-Statement aus und uebergibt das Resultset an den Extractor.
+   * Fuehrt ein SQL-Statement aus und uebergibt das {@link ResultSet} an den Extractor.
    * @param sql das Statement.
    * @param params die Parameter zur Erzeugung des PreparedStatements.
    * @param extractor der Extractor.

--- a/src/de/willuhn/datasource/rmi/Listener.java
+++ b/src/de/willuhn/datasource/rmi/Listener.java
@@ -14,12 +14,12 @@ import java.rmi.Remote;
 import java.rmi.RemoteException;
 
 /**
- * Ein Listener, der ueber Aenderungen an DBObjects benachrichtigt wird.
+ * Ein Listener, der ueber Aenderungen an {@link DBObject}s benachrichtigt wird.
  */
 public interface Listener extends Remote
 {
 	/**
-	 * Wird bei Aenderungen des DBObjects aufgerufen.
+	 * Wird bei Aenderungen des {@link DBObject}s aufgerufen.
    * @param e das ausgeloeste Event.
    * @throws RemoteException
    */

--- a/src/de/willuhn/datasource/rmi/ResultSetExtractor.java
+++ b/src/de/willuhn/datasource/rmi/ResultSetExtractor.java
@@ -22,7 +22,7 @@ import java.sql.SQLException;
 public interface ResultSetExtractor extends Remote
 {
   /**
-   * Wird vom DBService aufgerufen.
+   * Wird vom {@link DBService} aufgerufen.
    * @param rs das erzeugte Resultset.
    * @return das extrahierte Objekt.
    * @throws RemoteException

--- a/src/de/willuhn/datasource/rmi/Transactionable.java
+++ b/src/de/willuhn/datasource/rmi/Transactionable.java
@@ -20,20 +20,22 @@ public interface Transactionable
 
   /**
    * Damit kann man manuell eine Transaktion starten.
-   * Normalerweise wir bei store() oder delete() sofort
+   *
+   * <p>Normalerweise wird bei {@code store()} oder {@code delete()} sofort
    * bei Erfolg ein commit gemacht. Wenn man aber von
    * aussen das Transaktionsverhalten beeinflussen will,
    * kann man diese Methode aufrufen. Hat man dies
-   * getan, werden store() und delete() erst dann in
+   * getan, werden {@code store()} oder {@code delete()} erst dann in
    * der Datenbank ausgefuehrt, wenn man anschliessend
-   * transactionCommit() aufruft.
+   * {@link #transactionCommit()} aufruft.
    * @throws RemoteException im Fehlerfall.
    */
   public void transactionBegin() throws RemoteException;
   
   /**
    * Beendet eine manuell gestartete Transaktion.
-   * Wenn vorher kein <code>transactionBegin()</code> aufgerufen wurde,
+   *
+   * <p>Wenn vorher kein {@link #transactionBegin()} aufgerufen wurde,
    * wird dieser Aufruf ignoriert.
    * @throws RemoteException im Fehlerfall.
    */

--- a/src/de/willuhn/datasource/serialize/AbstractXmlIO.java
+++ b/src/de/willuhn/datasource/serialize/AbstractXmlIO.java
@@ -76,7 +76,7 @@ public abstract class AbstractXmlIO implements IO
   }
   
   /**
-   * Implementierung fuer Strings.
+   * Implementierung fuer {@link java.lang.String}.
    */
   protected static class StringValue extends AbstractValue
   {
@@ -90,7 +90,7 @@ public abstract class AbstractXmlIO implements IO
   }
 
   /**
-   * Implementierung fuer Double.
+   * Implementierung fuer {@link java.lang.Double}.
    */
   protected static class DoubleValue extends AbstractValue
   {
@@ -104,7 +104,7 @@ public abstract class AbstractXmlIO implements IO
   }
   
   /**
-   * Implementierung fuer BigDecimal.
+   * Implementierung fuer {@link java.math.BigDecimal}.
    */
   protected static class BigDecimalValue extends AbstractValue
   {
@@ -118,7 +118,7 @@ public abstract class AbstractXmlIO implements IO
   }
 
   /**
-   * Implementierung fuer Integer.
+   * Implementierung fuer {@link java.lang.Integer}.
    */
   protected static class IntegerValue extends AbstractValue
   {
@@ -132,7 +132,7 @@ public abstract class AbstractXmlIO implements IO
   }
 
   /**
-   * Implementierung fuer Long.
+   * Implementierung fuer {@link java.lang.Long}.
    */
   protected static class LongValue extends AbstractValue
   {
@@ -146,7 +146,7 @@ public abstract class AbstractXmlIO implements IO
   }
   
   /**
-   * Implementierung fuer Boolean.
+   * Implementierung fuer {@link java.lang.Boolean}.
    */
   protected static class BooleanValue extends AbstractValue
   {
@@ -160,7 +160,7 @@ public abstract class AbstractXmlIO implements IO
   }
 
   /**
-   * Implementierung fuer java.util.Date.
+   * Implementierung fuer {@link java.util.Date}.
    */
   protected static class DateValue implements Value
   {
@@ -194,7 +194,7 @@ public abstract class AbstractXmlIO implements IO
   }
   
   /**
-   * Implementierung fuer java.sql.Date.
+   * Implementierung fuer {@link java.sql.Date}.
    */
   protected static class SqlDateValue extends DateValue
   {
@@ -209,7 +209,7 @@ public abstract class AbstractXmlIO implements IO
   }
 
   /**
-   * Implementierung fuer java.sql.Timestamp.
+   * Implementierung fuer {@link java.sql.Timestamp}.
    */
   protected static class TimestampValue extends DateValue
   {
@@ -224,7 +224,7 @@ public abstract class AbstractXmlIO implements IO
   }
   
   /**
-   * Implementierung fuer Byte-Arrays.
+   * Implementierung fuer {@link java.lang.Byte}-Arrays.
    */
   protected static class ByteArrayValue implements Value
   {

--- a/src/de/willuhn/datasource/serialize/Reader.java
+++ b/src/de/willuhn/datasource/serialize/Reader.java
@@ -16,14 +16,15 @@ import java.io.IOException;
 import de.willuhn.datasource.GenericObject;
 
 /**
- * Interface zum Lesen von Objekten des Typs GenericObject.
+ * Interface zum Lesen von Objekten des Typs {@link GenericObject}.
  */
 public interface Reader extends IO
 {
   /**
    * Liest das naechste Objekt aus dem Reader.
+   *
    * @return das naechste verfuegbare Objekt.
-   * Wenn die Funktion <code>null</code> liefert,
+   * Wenn die Funktion {@code null} liefert,
    * ist der Reader "am Ende angekommen".
    * @throws IOException
    */

--- a/src/de/willuhn/datasource/serialize/Writer.java
+++ b/src/de/willuhn/datasource/serialize/Writer.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import de.willuhn.datasource.GenericObject;
 
 /**
- * Interface zum Schreiben von Objekten des Typs GenericObject.
+ * Interface zum Schreiben von Objekten des Typs {@link GenericObject}.
  */
 public interface Writer extends IO
 {

--- a/src/de/willuhn/datasource/serialize/XmlWriter.java
+++ b/src/de/willuhn/datasource/serialize/XmlWriter.java
@@ -78,9 +78,12 @@ public class XmlWriter extends AbstractXmlIO implements Writer
   
   /**
    * Liefert die Namen der zu serialisierenden Attributes des Objektes.
-   * Kann bei Bedarf ueberschrieben werden.
-   * Die Default-Implementierung ruft die Methode "getAttributeNames()"
-   * von GenericObject auf.
+   *
+   * <p>Kann bei Bedarf ueberschrieben werden.
+   *
+   * <p>Die Default-Implementierung ruft die Methode
+   * {@link GenericObject#getAttributeNames()} auf.
+   *
    * @param object das zu serialisierende Objekt.
    * @return die zu serialisierenden Attributes.
    * @throws RemoteException


### PR DESCRIPTION
Javadoc läuft auf Fehler wegen spitzer Klammern, die es als HTML-Tags interpretiert. Bei der Korrektur jener Fehler fielen mir noch weitere Auffälligkeiten und Optimierungspotentiale auf, die hier ebenfalls (als gesonderte Commits für einfacheres Review) enthalten sind.