### PR TITLE
Metadaten Suche auch Datenbank mit einbeziehen

### DIFF
--- a/src/de/willuhn/datasource/db/AbstractDBObject.java
+++ b/src/de/willuhn/datasource/db/AbstractDBObject.java
@@ -165,12 +165,14 @@ public abstract class AbstractDBObject extends UnicastRemoteObject implements DB
 		  String schema = System.getProperty(getService().getClass().getName() + ".schema",null); // BUGZILLA 960
 		  try
 		  {
-	      meta = getConnection().getMetaData().getColumns(null,schema,tableName,null);
+        meta = getConnection().getMetaData().getColumns(conn.getCatalog(),
+            schema, tableName, null);
 		  }
 		  catch (Exception e)
 		  {
 		    Logger.trace("unable to fetch table meta-data using NULL column name pattern, trying '%', see https://bugs.mysql.com/bug.php?id=81105");
-        meta = getConnection().getMetaData().getColumns(null,schema,tableName,"%");
+        meta = getConnection().getMetaData().getColumns(conn.getCatalog(),
+            schema, tableName, "%");
 		  }
 			String field;
       if (!meta.next())


### PR DESCRIPTION
Es gibt ja immer wieder das Problem bei der Nutzung von MySQL, dass die Falsche Tabelle gelesen wird, wenn der MySQL Nutzer Zugriff auf mehrere Datenbanken hat. Ich glaube ich habe die Ursache gefunden, bei der Suche der Metadaten der Tabelle wurde nur nach dem Tabellen-Namen, nicht nach dem Datenbank-Namen gesucht. Wenn dieser mit angegeben wird, klappt es.
Oder ist das absichtlich so definiert und hat irgendwelche Nebenwirkungen die ich nicht sehe?